### PR TITLE
remove blank lines from file before parsing it

### DIFF
--- a/lib/rails_admin_import/import.rb
+++ b/lib/rails_admin_import/import.rb
@@ -64,8 +64,8 @@ module RailsAdminImport
             FileUtils.copy(params[:file].tempfile, "#{Rails.root}/log/import/#{Time.now.strftime("%Y-%m-%d-%H-%M-%S")}-import.csv")
           end
 
-          text       = File.read(params[:file].tempfile)
-          clean      = text.force_encoding('BINARY').encode('UTF-8', :undef => :replace, :replace => '').gsub(/\n$/, '')
+          text       = File.read(params[:file].tempfile).strip!
+          clean      = text.force_encoding('BINARY').encode('UTF-8', :undef => :replace, :replace => '').gsub(/\n$/, '').gsub(/\r$/, '')
           file_check = CSV.new(clean)
           logger     = ImportLogger.new
      


### PR DESCRIPTION
Skip error when an csv file has blank lines by removing all of them before parsing it.
